### PR TITLE
Generate shell completions with clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ email = "0.0"
 clap = "2"
 vobject = "0.2"
 cursive = "0.5"
+
+[build-dependencies]
+clap = "2"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ work.
 2. Add `~/.cargo/bin/` to your path. The binary inside it doesn't depend on
    either Rust or Cargo, just `glibc` and `grep`.
 
+### Shell completions
+
+Shell completion files are included in the ArchLinux package for Bash, Fish,
+and Zsh. `cargo install` currently does not support installing additional
+files.
+
+If building from source, they will be found in
+`target/release/build/mates-<hash>/out/<shellfile>`.
+
 
 ## Usage
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+extern crate clap;
+
+use std::env;
+use std::fs;
+
+use clap::Shell;
+
+#[path = "src/mates/app.rs"]
+mod app;
+
+fn main() {
+    let outdir = match env::var_os("OUT_DIR") {
+        None => return,
+        Some(outdir) => outdir,
+    };
+    fs::create_dir_all(&outdir).unwrap();
+
+    let mut app = app::app();
+    app.gen_completions("mates", Shell::Bash, &outdir);
+    app.gen_completions("mates", Shell::Fish, &outdir);
+    app.gen_completions("mates", Shell::Zsh, &outdir);
+}

--- a/src/mates/app.rs
+++ b/src/mates/app.rs
@@ -1,0 +1,25 @@
+use clap::{App, Arg, AppSettings, SubCommand};
+
+pub fn app() -> App<'static, 'static> {
+    App::new("mates")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author("Markus Unterwaditzer")
+        .about("A simple commandline addressbook")
+        .setting(AppSettings::SubcommandRequired)
+        .subcommand(SubCommand::with_name("index")
+                    .about("Rewrite/create the index"))
+        .subcommand(SubCommand::with_name("mutt-query")
+                    .about("Search for contact, output is usable for mutt's query_command.")
+                    .arg(Arg::with_name("query").index(1)))
+        .subcommand(SubCommand::with_name("file-query")
+                    .about("Search for contact, return just the filename.")
+                    .arg(Arg::with_name("query").index(1)))
+        .subcommand(SubCommand::with_name("email-query")
+                    .about("Search for contact, return \"name <email>\".")
+                    .arg(Arg::with_name("query").index(1)))
+        .subcommand(SubCommand::with_name("add")
+                    .about("Take mail from stdin, add sender to contacts. Print filename."))
+        .subcommand(SubCommand::with_name("edit")
+                    .about("Open contact (given by filepath or search-string) interactively.")
+                    .arg(Arg::with_name("file-or-query").index(1)))
+}

--- a/src/mates/cli.rs
+++ b/src/mates/cli.rs
@@ -7,11 +7,11 @@ use std::io;
 use std::path;
 use std::process;
 
-use clap::{Arg,App,SubCommand,AppSettings};
 use atomicwrites::{AtomicFile,AllowOverwrite};
 
 use utils;
 use utils::CustomPathExt;
+use app;
 use editor;
 
 
@@ -95,28 +95,7 @@ pub fn cli_main() {
 }
 
 pub fn cli_main_raw() -> MainResult<()> {
-    let matches = App::new("mates")
-        .version(env!("CARGO_PKG_VERSION"))
-        .author("Markus Unterwaditzer")
-        .about("A simple commandline addressbook")
-        .setting(AppSettings::SubcommandRequired)
-        .subcommand(SubCommand::with_name("index")
-                    .about("Rewrite/create the index"))
-        .subcommand(SubCommand::with_name("mutt-query")
-                    .about("Search for contact, output is usable for mutt's query_command.")
-                    .arg(Arg::with_name("query").index(1)))
-        .subcommand(SubCommand::with_name("file-query")
-                    .about("Search for contact, return just the filename.")
-                    .arg(Arg::with_name("query").index(1)))
-        .subcommand(SubCommand::with_name("email-query")
-                    .about("Search for contact, return \"name <email>\".")
-                    .arg(Arg::with_name("query").index(1)))
-        .subcommand(SubCommand::with_name("add")
-                    .about("Take mail from stdin, add sender to contacts. Print filename."))
-        .subcommand(SubCommand::with_name("edit")
-                    .about("Open contact (given by filepath or search-string) interactively.")
-                    .arg(Arg::with_name("file-or-query").index(1)))
-        .get_matches();
+    let matches = app::app().get_matches();
 
     let command = matches.subcommand_name().unwrap();
 

--- a/src/mates/lib.rs
+++ b/src/mates/lib.rs
@@ -5,6 +5,7 @@ extern crate atomicwrites;
 extern crate clap;
 extern crate cursive;
 
+pub mod app;
 pub mod cli;
 mod utils;
 mod editor;


### PR DESCRIPTION
Clap can generate [compile-time shell completions](https://kbknapp.github.io/clap-rs/clap/struct.App.html#method.gen_completions). This commit adds support for it, and the completions can then be packaged with distribution (like how Ripgrep does its PKGBUILD) or installed by users.